### PR TITLE
Fix stage emoji off-by-one indexing error

### DIFF
--- a/src/FindCalendar.tsx
+++ b/src/FindCalendar.tsx
@@ -107,7 +107,7 @@ function FindCalendar() {
             const emojis = ["😕", "☹️", "😖", "😤", "😡", "🤬", "🔪", "☠️"]
 
             setEvents(events.map(e => { return {
-                title: "🔌 " + prettifyTitle(e.area_name) + " Stage " + e.stage + emojis[e.stage],
+                title: "🔌 " + prettifyTitle(e.area_name) + " Stage " + e.stage + emojis[e.stage-1],
                 start: e.start,
                 end: e.finsh,
             }}))


### PR DESCRIPTION
Emojis are indexed by stage (starting from 1) instead of stage-1. When stage 8 is used, this results in 'undefined' appearing in the calendar instead of the correct emoji.