### PR TITLE
Fix undefined location selector value issue

### DIFF
--- a/src/FindCalendar.tsx
+++ b/src/FindCalendar.tsx
@@ -121,7 +121,9 @@ function FindCalendar() {
         {/* Yes this ternary is disgusting, but it'll get cleared up in a bit*/}
         { (!error && isLoaded) ? <Autocomplete
             onChange={(_event, value) => {
-                setItemIdx(items.findIndex(item => item["label"] === value?.label))
+                setItemIdx( prevItemIdx => {
+                    return value ? items.findIndex(item => item["label"] === value?.label) : prevItemIdx
+                })
             }}
             isOptionEqualToValue={(option: Item, value: Item) => option.label === value.label}
             id="autocomplete-areas"


### PR DESCRIPTION
If you clear the "1. Find your location" selector (by clicking on the 'x' button or using backspace), an error is thrown, preventing the page from rendering correctly. This is cause by an undefined ```value``` parameter in the ```Autocomplete``` ```onChange``` function. The fix defaults to the current previous/last itemIdx in such a case.