### PR TITLE
Sort calendars naturally: "calendar-1" < "calendar-10"

### DIFF
--- a/src/AreaAutoComplete.tsx
+++ b/src/AreaAutoComplete.tsx
@@ -26,6 +26,18 @@ function AreaAutoComplete({result, value, onChange, hideCalendar}: AreaAutoCompl
             </Typography>
         </a>
     )
+
+    // Use a sorting collator for performance
+    // https://stackoverflow.com/a/38641281/14555505
+    const collator = new Intl.Collator(undefined, {numeric: true, sensitivity: "base"})
+    // Sort the results "naturally" such that `eskom-1` < `eskom-9` < `eskom-10`
+    const options = result.state === "ready"
+        ? result.content.sort((a, b) => collator.compare(
+            a.calendar_name.replace(/[-_.]/g, " "),
+            b.calendar_name.replace(/[-_.]/g, " ")
+        ))
+        : []
+
     return (
         <Autocomplete
             autoComplete
@@ -38,7 +50,7 @@ function AreaAutoComplete({result, value, onChange, hideCalendar}: AreaAutoCompl
             loading={["unsent", "loading"].includes(result.state)}
             noOptionsText={noOptionsComponent}
             onChange={onChange}
-            options={result.state === "ready" ? result.content : []}
+            options={options}
             renderOption={(props, option, state) => state.inputValue.length > 2 ? <AreaAutoCompleteOption state={state} props={props} option={option}/> : undefined}
             value={value}
             sx={{

--- a/src/EskomCalendar.tsx
+++ b/src/EskomCalendar.tsx
@@ -128,37 +128,6 @@ export function prettifyName(name: string | undefined) {
 }
 
 
-/**
- * Custom sorting function for sorting strings with city names and numbers.
- * @param {string} a - First string to compare.
- * @param {string} b - Second string to compare.
- * @returns {number} - Returns -1 if a should come before b, 1 if a should come after b, or 0 if they are equal.
- */
-function sortNamesAlphaNumerically(a,b){
-  // Extract the city name and number from each string
-  const aParts = a.split(' ');
-  const bParts = b.split(' ');
-  const aCity = aParts.slice(0, -1).join(' ');
-  const bCity = bParts.slice(0, -1).join(' ');
-  const aNumber = parseInt(aParts[aParts.length - 1], 10);
-  const bNumber = parseInt(bParts[bParts.length - 1], 10);
-
-  // Compare the city name
-  if (aCity < bCity) {
-    return -1;
-  } else if (aCity > bCity) {
-    return 1;
-  } else {
-    // If the city names are the same, compare the numbers
-    if (aNumber < bNumber) {
-      return -1;
-    } else if (aNumber > bNumber) {
-      return 1;
-    } else {
-      return 0;
-    }
-  }
-}
 
 const getReleaseAssets = async () => {
     const octokit = new Octokit({
@@ -220,9 +189,9 @@ const downloadAreaMetadata = async() => {
             return  (jsyaml.load(yaml) as {area_details: AreaMetadata[]})["area_details"]
                 .sort((a, b) => {
                     if (a.province !== undefined && b.province !== undefined) {
-                        return sortNamesAlphaNumerically(a.province, b.province)
+                        return a.province.localeCompare(b.province)
                     } else {
-                        return sortNamesAlphaNumerically(a.calendar_name, b.calendar_name)
+                        return a.calendar_name.localeCompare(b.calendar_name)
                     }
                 })
         })

--- a/src/EskomCalendar.tsx
+++ b/src/EskomCalendar.tsx
@@ -127,8 +127,6 @@ export function prettifyName(name: string | undefined) {
         .replace("Gauteng Tshwane Group", "Tshwane")
 }
 
-
-
 const getReleaseAssets = async () => {
     const octokit = new Octokit({
         auth: process.env.GH_PAGES_ENV_PAT || process.env.GH_PAGES_PAT

--- a/src/EskomCalendar.tsx
+++ b/src/EskomCalendar.tsx
@@ -127,6 +127,39 @@ export function prettifyName(name: string | undefined) {
         .replace("Gauteng Tshwane Group", "Tshwane")
 }
 
+
+/**
+ * Custom sorting function for sorting strings with city names and numbers.
+ * @param {string} a - First string to compare.
+ * @param {string} b - Second string to compare.
+ * @returns {number} - Returns -1 if a should come before b, 1 if a should come after b, or 0 if they are equal.
+ */
+function sortNamesAlphaNumerically(a,b){
+  // Extract the city name and number from each string
+  const aParts = a.split(' ');
+  const bParts = b.split(' ');
+  const aCity = aParts.slice(0, -1).join(' ');
+  const bCity = bParts.slice(0, -1).join(' ');
+  const aNumber = parseInt(aParts[aParts.length - 1], 10);
+  const bNumber = parseInt(bParts[bParts.length - 1], 10);
+
+  // Compare the city name
+  if (aCity < bCity) {
+    return -1;
+  } else if (aCity > bCity) {
+    return 1;
+  } else {
+    // If the city names are the same, compare the numbers
+    if (aNumber < bNumber) {
+      return -1;
+    } else if (aNumber > bNumber) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}
+
 const getReleaseAssets = async () => {
     const octokit = new Octokit({
         auth: process.env.GH_PAGES_ENV_PAT || process.env.GH_PAGES_PAT
@@ -187,9 +220,9 @@ const downloadAreaMetadata = async() => {
             return  (jsyaml.load(yaml) as {area_details: AreaMetadata[]})["area_details"]
                 .sort((a, b) => {
                     if (a.province !== undefined && b.province !== undefined) {
-                        return a.province.localeCompare(b.province)
+                        return sortNamesAlphaNumerically(a.province, b.province)
                     } else {
-                        return a.calendar_name.localeCompare(b.calendar_name)
+                        return sortNamesAlphaNumerically(a.calendar_name, b.calendar_name)
                     }
                 })
         })


### PR DESCRIPTION
Adds a new sorting function to sort names of places in a more intuitive ordering.
Sorts the area details alphabetically by city name and number. This improves the usability of the calendar by making it easier to find specific areas.

Fixes beyarkay/eskom-calendar#236
